### PR TITLE
修正云音乐 Mac 3.x 版本的 ncm 文件兼容性问题

### DIFF
--- a/src/ncmcrypt.cpp
+++ b/src/ncmcrypt.cpp
@@ -391,12 +391,14 @@ NeteaseCrypt::NeteaseCrypt(std::string const &path)
         mMetaData = new NeteaseMusicMetadata(cJSON_Parse(modifyDecryptData.c_str()));
     }
 
-    // skip crc32 & unuse charset
-    if (!mFile.seekg(9, mFile.cur))
+    // skip crc32 & image version
+    if (!mFile.seekg(5, mFile.cur))
     {
         throw std::invalid_argument("can't seek file");
     }
 
+    uint32_t cover_frame_len{0};
+    read(reinterpret_cast<char *>(&cover_frame_len), 4);
     read(reinterpret_cast<char *>(&n), sizeof(n));
 
     if (n > 0)
@@ -410,4 +412,5 @@ NeteaseCrypt::NeteaseCrypt(std::string const &path)
     {
         std::cout << "[Warn] " << path << " missing album can't fix album image!" << std::endl;
     }
+    mFile.seekg(cover_frame_len - n, mFile.cur);
 }

--- a/src/ncmcrypt.cpp
+++ b/src/ncmcrypt.cpp
@@ -403,10 +403,8 @@ NeteaseCrypt::NeteaseCrypt(std::string const &path)
 
     if (n > 0)
     {
-        char *imageData = (char *)malloc(n);
-        read(imageData, n);
-
-        mImageData = std::string(imageData, n);
+        mImageData = std::string(n, '\0');
+        read(&mImageData[0], n);
     }
     else
     {


### PR DESCRIPTION
该 PR 解决了下述问题：

- 修正问题 #26
- 修正封面数据的内存泄漏

---

https://github.com/taurusxin/ncmdump/blob/6eb36497538aba1b4cd52520d0b3fd5e3d10e1b4/src/ncmcrypt.cpp#L395 

之前的代码跳过了 9 个字节，但后 4 字节其实是有用的。

从 `crc32` 开始的数据结构如下：

```rs
u32 crc32
u8 version
u32 cover_frame_len
---
u32 image1_len
u8[image1_len] image1
u8[cover_frame_len-image1_len] image2
---
u8[] encrypted_audio
```