### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/src/utils/cJSON.cpp
+++ b/src/utils/cJSON.cpp
@@ -2142,7 +2142,7 @@ CJSON_PUBLIC(void) cJSON_InsertItemInArray(cJSON *array, int which, cJSON *newit
 {
     cJSON *after_inserted = NULL;
 
-    if (which < 0)
+    if (which < 0 || newitem == NULL)
     {
         return;
     }
@@ -2151,6 +2151,10 @@ CJSON_PUBLIC(void) cJSON_InsertItemInArray(cJSON *array, int which, cJSON *newit
     if (after_inserted == NULL)
     {
         add_item_to_array(array, newitem);
+        return;
+    }
+
+    if (after_inserted != array->child && newitem->prev == NULL) {
         return;
     }
 


### PR DESCRIPTION
Hi Development Team,

I identified a potential null pointer dereference in a clone function cJSON_InsertItemInArray() in `src/utils/cJSON.cpp` sourced from [DaveGamble/cJSON](https://github.com/DaveGamble/cJSON). This issue, originally reported in [CVE-2023-50471](https://nvd.nist.gov/vuln/detail/cve-2023-50471), was resolved in the repository via this commit https://github.com/DaveGamble/cJSON/commit/60ff122ef5862d04b39b150541459e7f5e35add8.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!